### PR TITLE
Set the logging of unknown properties to trace level and not warning

### DIFF
--- a/src/main/java/info/movito/themoviedbapi/model/core/AbstractJsonMapping.java
+++ b/src/main/java/info/movito/themoviedbapi/model/core/AbstractJsonMapping.java
@@ -31,7 +31,7 @@ public abstract class AbstractJsonMapping implements Serializable {
         sb.append("Unknown property: '").append(key);
         sb.append("' value: '").append(value).append("'");
 
-        getLogger(this.getClass()).warn(sb.toString());
+        getLogger(this.getClass()).trace(sb.toString());
     }
 
 


### PR DESCRIPTION
Thanks for publishing this easy to use API.

The unknown property was being logged at warning level in one place and trace in another. It generated huge amounts of noise despite the API operating perfectly (as far as I could tell). 
