### PR TITLE
Turned Timezone into a simple name=>country pair

### DIFF
--- a/src/main/java/info/movito/themoviedbapi/TmdbTimezones.java
+++ b/src/main/java/info/movito/themoviedbapi/TmdbTimezones.java
@@ -2,11 +2,13 @@ package info.movito.themoviedbapi;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
+
 import info.movito.themoviedbapi.model.config.Timezone;
 import info.movito.themoviedbapi.tools.ApiUrl;
 import info.movito.themoviedbapi.tools.RequestMethod;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -34,15 +36,15 @@ public class TmdbTimezones extends AbstractTmdbApi {
             throw new RuntimeException(e);
         }
 
-        List<Timezone> timezones = Lists.transform(Arrays.asList(hashMaps1), new Function<HashMap, Timezone>() {
-            @Override
-            public Timezone apply(HashMap input) {
-                String zoneName = input.keySet().iterator().next().toString();
-                return new Timezone(zoneName, (List<String>) input.get(zoneName));
-            }
-        });
+        ArrayList<Timezone> tzlist = new  ArrayList<Timezone>();
+        for(HashMap hm : Arrays.asList(hashMaps1)) {
+        	String zoneCountry = hm.keySet().iterator().next().toString();
+        	for( String zoneName : (List<String>)hm.get(zoneCountry)) {
+        		tzlist.add(new Timezone(zoneName,zoneCountry));
+        	}
+        }
 
-        return Lists.newArrayList(timezones);
+        return Lists.newArrayList(tzlist);
 
     }
 }

--- a/src/main/java/info/movito/themoviedbapi/model/config/Timezone.java
+++ b/src/main/java/info/movito/themoviedbapi/model/config/Timezone.java
@@ -8,19 +8,20 @@ import java.util.List;
 public class Timezone extends AbstractJsonMapping {
 
     private String name;
-    private List<String> countries;
+    private String country;
 
 
-    public Timezone(String name, List<String> countries) {
+    public Timezone(String name, String country) {
         this.name = name;
-        this.countries = countries;
+        this.country = country;
     }
 
 
-    public Collection<String> getCountries() {
-        return countries;
-    }
 
+	public String getCountry() {
+        return country;
+    }
+    
 
     public String getName() {
         return name;

--- a/src/test/java/info/movito/themoviedbapi/SeriesApiTest.java
+++ b/src/test/java/info/movito/themoviedbapi/SeriesApiTest.java
@@ -78,13 +78,15 @@ public class SeriesApiTest extends AbstractTmdbApiTest {
 
     @Test
     public void testAiringToday() {
-        Timezone ca = Iterables.find(tmdb.getTimezones(), new Predicate<Timezone>() {
+    	// Try t find the first (off possibly many timezones) listed
+    	// for 'US'
+    	
+    	Timezone ca = Iterables.find(tmdb.getTimezones(), new Predicate<Timezone>() {
             @Override
             public boolean apply(Timezone input) {
-                return input.getName().equals("US");
+                return input.getCountry().equals("US");
             }
         });
-
         TvResultsPage en = tmdb.getTvSeries().getAiringToday("en", null, ca);
         Assert.assertFalse(en.getResults().isEmpty());
     }

--- a/src/test/java/info/movito/themoviedbapi/SeriesApiTest.java
+++ b/src/test/java/info/movito/themoviedbapi/SeriesApiTest.java
@@ -78,7 +78,7 @@ public class SeriesApiTest extends AbstractTmdbApiTest {
 
     @Test
     public void testAiringToday() {
-    	// Try t find the first (off possibly many timezones) listed
+    	// Try to find the first (of possibly many timezones) listed
     	// for 'US'
     	
     	Timezone ca = Iterables.find(tmdb.getTimezones(), new Predicate<Timezone>() {

--- a/src/test/java/info/movito/themoviedbapi/TimezonesApiTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TimezonesApiTest.java
@@ -1,10 +1,12 @@
 package info.movito.themoviedbapi;
 
 import info.movito.themoviedbapi.model.config.Timezone;
+
 import org.junit.Test;
 
 import java.util.List;
 import java.util.TimeZone;
+import java.util.TreeSet;
 
 import static org.junit.Assert.assertFalse;
 
@@ -12,13 +14,16 @@ public class TimezonesApiTest extends AbstractTmdbApiTest {
 
     @Test
     public void testGetAuthorisationToken() throws Exception {
-        List<Timezone> tz = tmdb.getTimezones();
-
-        for (Timezone id : tz) {
-            TimeZone t = TimeZone.getTimeZone(id.getName());
-            assertFalse("Timezone '" + id + "' is unknown", t == null);
+        List<Timezone> tzlist = tmdb.getTimezones();
+        TreeSet<String> tzset = new TreeSet();
+        
+        for (Timezone tz : tzlist) {
+            // Check if the time zone conforms to the JAVA TimeZone names 
+            TimeZone t = TimeZone.getTimeZone(tz.getName());
+            assertFalse("Timezone '" + tz + "' is unknown", t == null);
+            // Check If it is unique
+            assertFalse("Timezone '" + tz.getName() + "' already defined", tzlist.contains(tz.getName()));
+            tzset.add(tz.getName());
         }
-
-
     }
 }


### PR DESCRIPTION
Instead of country=>[names] which didn't work due to
https://plus.google.com/114487407381986451998/posts/VSppxEw8QrK
Now the primary Container for timezones is List<Timezone> with "name"
like 'Europe/Berlin' assumed (but not guaranteed) to be unique and
country like 'DE' being just a reminder which country this timezpne
belongs to.