### PR TITLE
Update getTopRatedMovies

### DIFF
--- a/src/main/java/info/movito/themoviedbapi/TmdbMovies.java
+++ b/src/main/java/info/movito/themoviedbapi/TmdbMovies.java
@@ -337,7 +337,7 @@ public class TmdbMovies extends AbstractTmdbApi {
      * @param page
      */
     public MovieResultsPage getTopRatedMovies(String language, Integer page) {
-        ApiUrl apiUrl = new ApiUrl(TMDB_METHOD_MOVIE, "top-rated");
+        ApiUrl apiUrl = new ApiUrl(TMDB_METHOD_MOVIE, "top_rated");
 
         apiUrl.addLanguage(language);
 


### PR DESCRIPTION
I'm getting the error "The resource you requested could not be found."  when using getTopRatedMovies. Probably in  "top-rated" should exist an underscore and not a "-". Could you please confirm that.