### PR TITLE
Add javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,12 @@
                     <target>1.6</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
Can be called as `mvn javadoc:javadoc` to generate javadocs. See https://maven.apache.org/plugins/maven-javadoc-plugin/usage.html.