### PR TITLE
releases is null when using appendToResponse

### DIFF
--- a/src/main/java/info/movito/themoviedbapi/model/MovieDb.java
+++ b/src/main/java/info/movito/themoviedbapi/model/MovieDb.java
@@ -93,7 +93,7 @@ public class MovieDb extends IdElement implements Multi {
     @JsonProperty("keywords")
     private MovieKeywords keywords;
 
-    @JsonProperty("releases")
+    @JsonProperty("release_dates")
     private TmdbMovies.ReleaseInfoResults releases;
 
     @JsonProperty("videos")
@@ -252,7 +252,7 @@ public class MovieDb extends IdElement implements Multi {
 
 
     public List<ReleaseInfo> getReleases() {
-        return releases != null ? releases.getResults() : null;
+        return releases.getResults() != null ? releases.getResults() : null;
     }
 
 

--- a/src/test/java/info/movito/themoviedbapi/MoviesApiTest.java
+++ b/src/test/java/info/movito/themoviedbapi/MoviesApiTest.java
@@ -28,7 +28,7 @@ public class MoviesApiTest extends AbstractTmdbApiTest {
         MovieDb result = tmdb.getMovies().getMovie(ID_MOVIE_BLADE_RUNNER, LANGUAGE_ENGLISH, TmdbMovies.MovieMethod.values());
         assertEquals("Incorrect movie information", "Blade Runner", result.getOriginalTitle());
         assertTrue("no videos", result.getVideos().size() > 0);
-
+        assertNotNull(result.getReleases());
     }
 
 


### PR DESCRIPTION
Hey, I went to implement release types in my own project and realized that MovieDb.releases is null when using appendToResponse rather than sending an independet request for releases.

Here's an update to fix that.