### PR TITLE
Implement watch providers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,8 @@ dependencies {
     api 'org.yamj:api-common:1.1'
 
     // testing
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:4.6.1'
 }
 
 java {

--- a/src/main/java/info/movito/themoviedbapi/TmdbMovies.java
+++ b/src/main/java/info/movito/themoviedbapi/TmdbMovies.java
@@ -7,6 +7,7 @@ import info.movito.themoviedbapi.model.core.IdElement;
 import info.movito.themoviedbapi.model.core.MovieResultsPage;
 import info.movito.themoviedbapi.model.core.SessionToken;
 import info.movito.themoviedbapi.model.keywords.Keyword;
+import info.movito.themoviedbapi.model.providers.ProviderResults;
 import info.movito.themoviedbapi.tools.ApiUrl;
 import org.apache.commons.lang3.StringUtils;
 
@@ -36,6 +37,24 @@ public class TmdbMovies extends AbstractTmdbApi {
         videos, // replacement for trailers
         translations, similar, recommendations,
         reviews, lists, changes, latest, upcoming, now_playing, popular, top_rated,
+        watch_providers("watch/providers");
+
+        private String name;
+
+        MovieMethod() {}
+
+        MovieMethod(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            if (name != null) {
+                return name;
+            }
+
+            return super.toString();
+        }
     }
 
 
@@ -46,7 +65,7 @@ public class TmdbMovies extends AbstractTmdbApi {
 
     /**
      * This method is used to retrieve all of the basic movie information.
-     * 
+     *
      * It will return the single highest rated poster and backdrop.
      */
     public MovieDb getMovie(int movieId, String language, MovieMethod... appendToResponse) {
@@ -96,7 +115,7 @@ public class TmdbMovies extends AbstractTmdbApi {
 
     /**
      * This method is used to retrieve all of the keywords that have been added to a particular movie.
-     * 
+     *
      * Currently, only English keywords exist.
      */
     public List<Keyword> getKeywords(int movieId) {
@@ -141,7 +160,7 @@ public class TmdbMovies extends AbstractTmdbApi {
 
     /**
      * This method is used to retrieve all of the videos for a particular movie.
-     * 
+     *
      * Supported sites are YouTube and QuickTime.
      */
     public List<Video> getVideos(int movieId, String language) {
@@ -165,9 +184,9 @@ public class TmdbMovies extends AbstractTmdbApi {
 
     /**
      * The similar movies method will let you retrieve the similar movies for a particular movie.
-     * 
+     *
      * This data is created dynamically but with the help of users votes on TMDb.
-     * 
+     *
      * The data is much better with movies that have more keywords
      */
     public MovieResultsPage getSimilarMovies(int movieId, String language, Integer page) {
@@ -182,9 +201,9 @@ public class TmdbMovies extends AbstractTmdbApi {
 
     /**
      * The recomendations movies method will let you retrieve the reccomended movies for a particular movie.
-     * 
+     *
      * This data is created dynamically but with the help of TMDb internal algorithm.
-     * 
+     *
      * The data is much better with movies that are more popular
      */
     public MovieResultsPage getRecommendedMovies(int movieId, String language, Integer page) {
@@ -216,15 +235,15 @@ public class TmdbMovies extends AbstractTmdbApi {
 
     /**
      * Get the changes for a specific movie id.
-     * 
+     *
      * Changes are grouped by key, and ordered by date in descending order.
-     * 
+     *
      * By default, only the last 24 hours of changes are returned.
-     * 
+     *
      * The maximum number of days that can be returned in a single request is 14.
-     * 
+     *
      * The language is present on fields that are translatable.
-     * 
+     *
      * TODO: DOES NOT WORK AT THE MOMENT. This is due to the "value" item changing type in the ChangeItem
      *
      * @param startDate the start date of the changes, optional
@@ -245,6 +264,24 @@ public class TmdbMovies extends AbstractTmdbApi {
 
     }
 
+    /**
+     * Powered by our partnership with JustWatch, you can query this method to get a list of the availabilities per country by provider.
+     * <p>
+     * This is not going to return full deep links, but rather, it's just enough information to display what's available where.
+     * <p>
+     * You can link to the provided TMDB URL to help support TMDB and provide the actual deep links to the content.
+     *
+     * See: <a href="https://developers.themoviedb.org/3/movies/get-movie-watch-providers">API Docs</a>
+     *
+     * @param movieId The MovieId to retrieve watch providers for
+     * @return Complete set of watch providers by country
+     */
+    public ProviderResults getWatchProviders(int movieId) {
+        ApiUrl apiUrl = new ApiUrl(TMDB_METHOD_MOVIE, movieId, MovieMethod.watch_providers);
+
+        return mapJsonResult(apiUrl, ProviderResults.class);
+    }
+
 
     /**
      * This method is used to retrieve the newest movie that was added to TMDb.
@@ -259,9 +296,9 @@ public class TmdbMovies extends AbstractTmdbApi {
 
     /**
      * Get the list of upcoming movies.
-     * 
+     *
      * This list refreshes every day.
-     * 
+     *
      * The maximum number of items this list will include is 100.
      * <p>
      * See https://developers.themoviedb.org/3/movies/get-upcoming
@@ -284,7 +321,7 @@ public class TmdbMovies extends AbstractTmdbApi {
 
     /**
      * This method is used to retrieve the movies currently in theatres.
-     * 
+     *
      * This is a curated list that will normally contain 100 movies. The default response will return 20 movies.
      */
     public MovieResultsPage getNowPlayingMovies(String language, Integer page, String region) {
@@ -304,7 +341,7 @@ public class TmdbMovies extends AbstractTmdbApi {
 
     /**
      * This method is used to retrieve the daily movie popularity list.
-     * 
+     *
      * This list is updated daily. The default response will return 20 movies.
      */
     public MovieResultsPage getPopularMovies(String language, Integer page) {
@@ -320,7 +357,7 @@ public class TmdbMovies extends AbstractTmdbApi {
 
     /**
      * This method is used to retrieve the top rated movies that have over 10 votes on TMDb.
-     * 
+     *
      * The default response will return 20 movies.
      */
     public MovieResultsPage getTopRatedMovies(String language, Integer page) {

--- a/src/main/java/info/movito/themoviedbapi/model/MovieDb.java
+++ b/src/main/java/info/movito/themoviedbapi/model/MovieDb.java
@@ -9,6 +9,7 @@ import info.movito.themoviedbapi.model.core.ResultsPage;
 import info.movito.themoviedbapi.model.keywords.Keyword;
 import info.movito.themoviedbapi.model.people.PersonCast;
 import info.movito.themoviedbapi.model.people.PersonCrew;
+import info.movito.themoviedbapi.model.providers.ProviderResults;
 
 import java.util.List;
 
@@ -122,6 +123,9 @@ public class MovieDb extends IdElement implements Multi {
 
     @JsonProperty("lists")
     private ResultsPage<MovieList> lists;
+
+    @JsonProperty("watch/providers")
+    private ProviderResults watchProviders;
 
 
     public String getBackdropPath() {
@@ -305,6 +309,9 @@ public class MovieDb extends IdElement implements Multi {
         return userRating;
     }
 
+    public ProviderResults getWatchProviders() {
+        return watchProviders;
+    }
 
     @Override
     public String toString() {
@@ -485,5 +492,9 @@ public class MovieDb extends IdElement implements Multi {
 
     public void setLists(ResultsPage<MovieList> lists) {
         this.lists = lists;
+    }
+
+    public void setWatchProviders(ProviderResults watchProviders) {
+        this.watchProviders = watchProviders;
     }
 }

--- a/src/main/java/info/movito/themoviedbapi/model/providers/Provider.java
+++ b/src/main/java/info/movito/themoviedbapi/model/providers/Provider.java
@@ -1,0 +1,54 @@
+package info.movito.themoviedbapi.model.providers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Provider {
+
+  @JsonProperty("display_priority")
+  private Integer displayPriority;
+
+  @JsonProperty("logo_path")
+  private String logoPath;
+
+  @JsonProperty("provider_id")
+  private Integer providerId;
+
+  @JsonProperty("provider_name")
+  private String providerName;
+
+  public Integer getDisplayPriority() {
+    return displayPriority;
+  }
+
+  public Provider setDisplayPriority(Integer displayPriority) {
+    this.displayPriority = displayPriority;
+    return this;
+  }
+
+  public String getLogoPath() {
+    return logoPath;
+  }
+
+  public Provider setLogoPath(String logoPath) {
+    this.logoPath = logoPath;
+    return this;
+  }
+
+  public Integer getProviderId() {
+    return providerId;
+  }
+
+  public Provider setProviderId(Integer providerId) {
+    this.providerId = providerId;
+    return this;
+  }
+
+  public String getProviderName() {
+    return providerName;
+  }
+
+  public Provider setProviderName(String providerName) {
+    this.providerName = providerName;
+    return this;
+  }
+}

--- a/src/main/java/info/movito/themoviedbapi/model/providers/ProviderResults.java
+++ b/src/main/java/info/movito/themoviedbapi/model/providers/ProviderResults.java
@@ -1,0 +1,27 @@
+package info.movito.themoviedbapi.model.providers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public class ProviderResults {
+
+  @JsonProperty("id")
+  private int id;
+
+  @JsonProperty("results")
+  private Map<String, WatchProviders> results;
+
+  public Map<String, WatchProviders> getResults() {
+    return results;
+  }
+
+  public ProviderResults setResults(Map<String, WatchProviders> results) {
+    this.results = results;
+    return this;
+  }
+
+  public WatchProviders getProvidersForCountry(String country) {
+    return results.getOrDefault(country, null);
+  }
+}

--- a/src/main/java/info/movito/themoviedbapi/model/providers/WatchProviders.java
+++ b/src/main/java/info/movito/themoviedbapi/model/providers/WatchProviders.java
@@ -1,0 +1,56 @@
+package info.movito.themoviedbapi.model.providers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class WatchProviders {
+
+  @JsonProperty("link")
+  private String link;
+
+  @JsonProperty("rent")
+  private List<Provider> rentProviders;
+
+  @JsonProperty("buy")
+  private List<Provider> buyProviders;
+
+  @JsonProperty("flatrate")
+  private List<Provider> flatrateProviders;
+
+  public String getLink() {
+    return link;
+  }
+
+  public WatchProviders setLink(String link) {
+    this.link = link;
+    return this;
+  }
+
+  public List<Provider> getRentProviders() {
+    return rentProviders;
+  }
+
+  public WatchProviders setRentProviders(List<Provider> rentProviders) {
+    this.rentProviders = rentProviders;
+    return this;
+  }
+
+  public List<Provider> getBuyProviders() {
+    return buyProviders;
+  }
+
+  public WatchProviders setBuyProviders(List<Provider> buyProviders) {
+    this.buyProviders = buyProviders;
+    return this;
+  }
+
+  public List<Provider> getFlatrateProviders() {
+    return flatrateProviders;
+  }
+
+  public WatchProviders setFlatrateProviders(List<Provider> flatrateProviders) {
+    this.flatrateProviders = flatrateProviders;
+    return this;
+  }
+}

--- a/src/test/java/info/movito/themoviedbapi/TestUtils.java
+++ b/src/test/java/info/movito/themoviedbapi/TestUtils.java
@@ -1,0 +1,29 @@
+package info.movito.themoviedbapi;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Objects;
+
+public class TestUtils {
+
+  private final static ObjectMapper objectMapper = new ObjectMapper();
+
+  public static String getFixture(String path) throws IOException {
+    File file = getFileFromClasspath(path);
+    return new String(Files.readAllBytes(file.toPath()));
+  }
+
+  public static <T> T getParsedFixture(String path, Class<T> clazz) throws IOException {
+    File file = getFileFromClasspath(path);
+    return objectMapper.readValue(file, clazz);
+  }
+
+  private static File getFileFromClasspath(String path) {
+    ClassLoader classLoader = TestUtils.class.getClassLoader();
+    return new File(Objects.requireNonNull(classLoader.getResource(path)).getFile());
+  }
+
+}

--- a/src/test/resources/fixtures/config_response.json
+++ b/src/test/resources/fixtures/config_response.json
@@ -1,0 +1,9 @@
+{
+  "images": {
+    "base_url": "https://example.com",
+    "secure_base_url": "https://example.com"
+  },
+  "change_keys": [
+    "123"
+  ]
+}

--- a/src/test/resources/fixtures/watch_providers.json
+++ b/src/test/resources/fixtures/watch_providers.json
@@ -1,0 +1,1782 @@
+{
+  "id": 526896,
+  "results": {
+    "AR": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=AR",
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 10,
+          "logo_path": "/lJT7r1nprk1Z8t1ywiIa8h9d3rc.jpg",
+          "provider_id": 167,
+          "provider_name": "Claro video"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ]
+    },
+    "AT": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=AT",
+      "flatrate": [
+        {
+          "display_priority": 41,
+          "logo_path": "/5OtaT8STJ8ZMkKt994C5XxrEAaP.jpg",
+          "provider_id": 622,
+          "provider_name": "UPC TV"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 10,
+          "logo_path": "/mT9kIe6JVz72ikWJ58x0q8ckUW3.jpg",
+          "provider_id": 40,
+          "provider_name": "Chili"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 15,
+          "logo_path": "/2PTFxgrswnEuK0szl87iSd8Yszz.jpg",
+          "provider_id": 20,
+          "provider_name": "maxdome Store"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 10,
+          "logo_path": "/mT9kIe6JVz72ikWJ58x0q8ckUW3.jpg",
+          "provider_id": 40,
+          "provider_name": "Chili"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 15,
+          "logo_path": "/2PTFxgrswnEuK0szl87iSd8Yszz.jpg",
+          "provider_id": 20,
+          "provider_name": "maxdome Store"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "AU": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=AU",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 13,
+          "logo_path": "/oIkQkEkwfmcG7IGpRR1NB8frZZM.jpg",
+          "provider_id": 192,
+          "provider_name": "YouTube"
+        },
+        {
+          "display_priority": 31,
+          "logo_path": "/zXDDsD9M5vO7lqoqlBQCOcZtKBS.jpg",
+          "provider_id": 429,
+          "provider_name": "Telstra TV"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        },
+        {
+          "display_priority": 13,
+          "logo_path": "/oIkQkEkwfmcG7IGpRR1NB8frZZM.jpg",
+          "provider_id": 192,
+          "provider_name": "YouTube"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "BE": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=BE",
+      "rent": [
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        }
+      ],
+      "flatrate": [
+        {
+          "display_priority": 12,
+          "logo_path": "/vjsvYNPgq6BpUoubXR1wNkokoBb.jpg",
+          "provider_id": 313,
+          "provider_name": "Yelo Play"
+        }
+      ]
+    },
+    "BO": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=BO",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        }
+      ]
+    },
+    "BR": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=BR",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ],
+      "flatrate": [
+        {
+          "display_priority": 25,
+          "logo_path": "/cQQYtdaCg7vDo28JPru4v8Ypi8x.jpg",
+          "provider_id": 484,
+          "provider_name": "NOW"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ]
+    },
+    "CA": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=CA",
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 12,
+          "logo_path": "/sN8B7EweqmOmWm5ALdOAxCquuv1.jpg",
+          "provider_id": 140,
+          "provider_name": "Cineplex"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 12,
+          "logo_path": "/sN8B7EweqmOmWm5ALdOAxCquuv1.jpg",
+          "provider_id": 140,
+          "provider_name": "Cineplex"
+        },
+        {
+          "display_priority": 13,
+          "logo_path": "/oIkQkEkwfmcG7IGpRR1NB8frZZM.jpg",
+          "provider_id": 192,
+          "provider_name": "YouTube"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "CH": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=CH",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/2LS6g6iE5DiAIDiZTAK8mbQQTuE.jpg",
+          "provider_id": 150,
+          "provider_name": "SwissCom"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/jmyYN1124dDIzqMysLekixy3AzF.jpg",
+          "provider_id": 164,
+          "provider_name": "Hollystar"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/2pCbao1J9s0DMak2KKnEzmzHni8.jpg",
+          "provider_id": 130,
+          "provider_name": "Sky Store"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ],
+      "flatrate": [
+        {
+          "display_priority": 41,
+          "logo_path": "/5OtaT8STJ8ZMkKt994C5XxrEAaP.jpg",
+          "provider_id": 622,
+          "provider_name": "UPC TV"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 3,
+          "logo_path": "/2LS6g6iE5DiAIDiZTAK8mbQQTuE.jpg",
+          "provider_id": 150,
+          "provider_name": "SwissCom"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/jmyYN1124dDIzqMysLekixy3AzF.jpg",
+          "provider_id": 164,
+          "provider_name": "Hollystar"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/2pCbao1J9s0DMak2KKnEzmzHni8.jpg",
+          "provider_id": 130,
+          "provider_name": "Sky Store"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "CL": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=CL",
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ]
+    },
+    "CO": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=CO",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        }
+      ]
+    },
+    "CR": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=CR",
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ]
+    },
+    "DE": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=DE",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 10,
+          "logo_path": "/mT9kIe6JVz72ikWJ58x0q8ckUW3.jpg",
+          "provider_id": 40,
+          "provider_name": "Chili"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 15,
+          "logo_path": "/2PTFxgrswnEuK0szl87iSd8Yszz.jpg",
+          "provider_id": 20,
+          "provider_name": "maxdome Store"
+        },
+        {
+          "display_priority": 28,
+          "logo_path": "/uULoezj2skPc6amfwru72UPjYXV.jpg",
+          "provider_id": 178,
+          "provider_name": "MagentaTV"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 10,
+          "logo_path": "/mT9kIe6JVz72ikWJ58x0q8ckUW3.jpg",
+          "provider_id": 40,
+          "provider_name": "Chili"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 15,
+          "logo_path": "/2PTFxgrswnEuK0szl87iSd8Yszz.jpg",
+          "provider_id": 20,
+          "provider_name": "maxdome Store"
+        },
+        {
+          "display_priority": 28,
+          "logo_path": "/uULoezj2skPc6amfwru72UPjYXV.jpg",
+          "provider_id": 178,
+          "provider_name": "MagentaTV"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "DK": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=DK",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 22,
+          "logo_path": "/dNcz2AZHPEgt4BIKJe56r4visuK.jpg",
+          "provider_id": 426,
+          "provider_name": "SF Anytime"
+        },
+        {
+          "display_priority": 25,
+          "logo_path": "/cvl65OJnz14LUlC3yGK1KHj8UYs.jpg",
+          "provider_id": 76,
+          "provider_name": "Viaplay"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "EC": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=EC",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        }
+      ]
+    },
+    "ES": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=ES",
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "FI": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=FI",
+      "buy": [
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 21,
+          "logo_path": "/3QsJbibv5dFW2IYuXbTjxDmGGRZ.jpg",
+          "provider_id": 423,
+          "provider_name": "Blockbuster"
+        },
+        {
+          "display_priority": 22,
+          "logo_path": "/dNcz2AZHPEgt4BIKJe56r4visuK.jpg",
+          "provider_id": 426,
+          "provider_name": "SF Anytime"
+        },
+        {
+          "display_priority": 25,
+          "logo_path": "/cvl65OJnz14LUlC3yGK1KHj8UYs.jpg",
+          "provider_id": 76,
+          "provider_name": "Viaplay"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "GB": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=GB",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/2pCbao1J9s0DMak2KKnEzmzHni8.jpg",
+          "provider_id": 130,
+          "provider_name": "Sky Store"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 10,
+          "logo_path": "/mT9kIe6JVz72ikWJ58x0q8ckUW3.jpg",
+          "provider_id": 40,
+          "provider_name": "Chili"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ],
+      "flatrate": [
+        {
+          "display_priority": 63,
+          "logo_path": "/o6li3XZrBKXSqyNRS39UQEfPTCH.jpg",
+          "provider_id": 594,
+          "provider_name": "Virgin TV Go"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/2pCbao1J9s0DMak2KKnEzmzHni8.jpg",
+          "provider_id": 130,
+          "provider_name": "Sky Store"
+        },
+        {
+          "display_priority": 10,
+          "logo_path": "/mT9kIe6JVz72ikWJ58x0q8ckUW3.jpg",
+          "provider_id": 40,
+          "provider_name": "Chili"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 13,
+          "logo_path": "/oIkQkEkwfmcG7IGpRR1NB8frZZM.jpg",
+          "provider_id": 192,
+          "provider_name": "YouTube"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "GT": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=GT",
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ]
+    },
+    "HN": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=HN",
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ]
+    },
+    "ID": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=ID",
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        },
+        {
+          "display_priority": 16,
+          "logo_path": "/45eTLxznKGY9xq50NBWjN4adVng.jpg",
+          "provider_id": 159,
+          "provider_name": "Catchplay"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ]
+    },
+    "IE": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=IE",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/2pCbao1J9s0DMak2KKnEzmzHni8.jpg",
+          "provider_id": 130,
+          "provider_name": "Sky Store"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/2pCbao1J9s0DMak2KKnEzmzHni8.jpg",
+          "provider_id": 130,
+          "provider_name": "Sky Store"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "IN": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=IN",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        },
+        {
+          "display_priority": 13,
+          "logo_path": "/oIkQkEkwfmcG7IGpRR1NB8frZZM.jpg",
+          "provider_id": 192,
+          "provider_name": "YouTube"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 2,
+          "logo_path": "/ajbCmwvZ8HiePHZaOVEgm9MzyuA.jpg",
+          "provider_id": 232,
+          "provider_name": "Zee5"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 13,
+          "logo_path": "/oIkQkEkwfmcG7IGpRR1NB8frZZM.jpg",
+          "provider_id": 192,
+          "provider_name": "YouTube"
+        }
+      ]
+    },
+    "IS": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=IS",
+      "buy": [
+        {
+          "display_priority": 25,
+          "logo_path": "/cvl65OJnz14LUlC3yGK1KHj8UYs.jpg",
+          "provider_id": 76,
+          "provider_name": "Viaplay"
+        }
+      ]
+    },
+    "IT": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=IT",
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 10,
+          "logo_path": "/mT9kIe6JVz72ikWJ58x0q8ckUW3.jpg",
+          "provider_id": 40,
+          "provider_name": "Chili"
+        },
+        {
+          "display_priority": 10,
+          "logo_path": "/j9iLCZMMgXP3jaYPkxCicx5Zmx3.jpg",
+          "provider_id": 359,
+          "provider_name": "Mediaset Play"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 13,
+          "logo_path": "/ftxHS1anAWTYgtDtIDv8VLXoepH.jpg",
+          "provider_id": 109,
+          "provider_name": "Timvision"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 10,
+          "logo_path": "/mT9kIe6JVz72ikWJ58x0q8ckUW3.jpg",
+          "provider_id": 40,
+          "provider_name": "Chili"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "JP": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=JP",
+      "buy": [
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 4,
+          "logo_path": "/9pS9Y3xkCLJnti9pi1AyrD5KbZe.jpg",
+          "provider_id": 84,
+          "provider_name": "U-NEXT"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "KR": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=KR",
+      "rent": [
+        {
+          "display_priority": 3,
+          "logo_path": "/2ioan5BX5L9tz4fIGU93blTeFhv.jpg",
+          "provider_id": 356,
+          "provider_name": "wavve"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 3,
+          "logo_path": "/2ioan5BX5L9tz4fIGU93blTeFhv.jpg",
+          "provider_id": 356,
+          "provider_name": "wavve"
+        }
+      ]
+    },
+    "MX": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=MX",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        },
+        {
+          "display_priority": 10,
+          "logo_path": "/lJT7r1nprk1Z8t1ywiIa8h9d3rc.jpg",
+          "provider_id": 167,
+          "provider_name": "Claro video"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 33,
+          "logo_path": "/qJxuBkjkXWYmuTKk7hxvbmqvrNc.jpg",
+          "provider_id": 558,
+          "provider_name": "Cinépolis KLIC"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        },
+        {
+          "display_priority": 10,
+          "logo_path": "/lJT7r1nprk1Z8t1ywiIa8h9d3rc.jpg",
+          "provider_id": 167,
+          "provider_name": "Claro video"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "MY": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=MY",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ]
+    },
+    "NL": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=NL",
+      "rent": [
+        {
+          "display_priority": 7,
+          "logo_path": "/llmnYOyknekZsXtkCaazKjhTLvG.jpg",
+          "provider_id": 71,
+          "provider_name": "Pathé Thuis"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        },
+        {
+          "display_priority": 49,
+          "logo_path": "/jWKX6kO7JqQbqVnu9QtEO6FC85n.jpg",
+          "provider_id": 697,
+          "provider_name": "meJane"
+        }
+      ],
+      "flatrate": [
+        {
+          "display_priority": 35,
+          "logo_path": "/bVClgB5bpaTRM3sVPlboaxkFD0U.jpg",
+          "provider_id": 563,
+          "provider_name": "KPN"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 7,
+          "logo_path": "/llmnYOyknekZsXtkCaazKjhTLvG.jpg",
+          "provider_id": 71,
+          "provider_name": "Pathé Thuis"
+        },
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "NO": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=NO",
+      "buy": [
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 21,
+          "logo_path": "/3QsJbibv5dFW2IYuXbTjxDmGGRZ.jpg",
+          "provider_id": 423,
+          "provider_name": "Blockbuster"
+        },
+        {
+          "display_priority": 22,
+          "logo_path": "/dNcz2AZHPEgt4BIKJe56r4visuK.jpg",
+          "provider_id": 426,
+          "provider_name": "SF Anytime"
+        },
+        {
+          "display_priority": 23,
+          "logo_path": "/5nECaP8nhtrzZfx7oG0yoFMfqiA.jpg",
+          "provider_id": 431,
+          "provider_name": "SumoTV"
+        },
+        {
+          "display_priority": 25,
+          "logo_path": "/cvl65OJnz14LUlC3yGK1KHj8UYs.jpg",
+          "provider_id": 76,
+          "provider_name": "Viaplay"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "NZ": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=NZ",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ]
+    },
+    "PE": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=PE",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        }
+      ]
+    },
+    "PH": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=PH",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ]
+    },
+    "PT": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=PT",
+      "rent": [
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        }
+      ]
+    },
+    "PY": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=PY",
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        }
+      ]
+    },
+    "SE": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=SE",
+      "buy": [
+        {
+          "display_priority": 8,
+          "logo_path": "/5GEbAhFW2S5T8zVc1MNvz00pIzM.jpg",
+          "provider_id": 35,
+          "provider_name": "Rakuten TV"
+        },
+        {
+          "display_priority": 21,
+          "logo_path": "/3QsJbibv5dFW2IYuXbTjxDmGGRZ.jpg",
+          "provider_id": 423,
+          "provider_name": "Blockbuster"
+        },
+        {
+          "display_priority": 22,
+          "logo_path": "/dNcz2AZHPEgt4BIKJe56r4visuK.jpg",
+          "provider_id": 426,
+          "provider_name": "SF Anytime"
+        },
+        {
+          "display_priority": 25,
+          "logo_path": "/cvl65OJnz14LUlC3yGK1KHj8UYs.jpg",
+          "provider_id": 76,
+          "provider_name": "Viaplay"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        }
+      ]
+    },
+    "SG": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=SG",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ]
+    },
+    "TH": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=TH",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ]
+    },
+    "TW": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=TW",
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        }
+      ]
+    },
+    "US": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=US",
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 13,
+          "logo_path": "/oIkQkEkwfmcG7IGpRR1NB8frZZM.jpg",
+          "provider_id": 192,
+          "provider_name": "YouTube"
+        },
+        {
+          "display_priority": 37,
+          "logo_path": "/21dEscfO8n1tL35k4DANixhffsR.jpg",
+          "provider_id": 7,
+          "provider_name": "Vudu"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        },
+        {
+          "display_priority": 50,
+          "logo_path": "/gbyLHzl4eYP0oP9oJZ2oKbpkhND.jpg",
+          "provider_id": 279,
+          "provider_name": "Redbox"
+        },
+        {
+          "display_priority": 54,
+          "logo_path": "/xL9SUR63qrEjFZAhtsipskeAMR7.jpg",
+          "provider_id": 358,
+          "provider_name": "DIRECTV"
+        },
+        {
+          "display_priority": 134,
+          "logo_path": "/kJlVJLgbNPvKDYC0YMp3yA2OKq2.jpg",
+          "provider_id": 352,
+          "provider_name": "AMC on Demand"
+        }
+      ],
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 11,
+          "logo_path": "/5NyLm42TmCqCMOZFvH4fcoSNKEW.jpg",
+          "provider_id": 10,
+          "provider_name": "Amazon Video"
+        },
+        {
+          "display_priority": 37,
+          "logo_path": "/21dEscfO8n1tL35k4DANixhffsR.jpg",
+          "provider_id": 7,
+          "provider_name": "Vudu"
+        },
+        {
+          "display_priority": 48,
+          "logo_path": "/shq88b09gTBYC4hA7K7MUL8Q4zP.jpg",
+          "provider_id": 68,
+          "provider_name": "Microsoft Store"
+        },
+        {
+          "display_priority": 50,
+          "logo_path": "/gbyLHzl4eYP0oP9oJZ2oKbpkhND.jpg",
+          "provider_id": 279,
+          "provider_name": "Redbox"
+        },
+        {
+          "display_priority": 54,
+          "logo_path": "/xL9SUR63qrEjFZAhtsipskeAMR7.jpg",
+          "provider_id": 358,
+          "provider_name": "DIRECTV"
+        },
+        {
+          "display_priority": 134,
+          "logo_path": "/kJlVJLgbNPvKDYC0YMp3yA2OKq2.jpg",
+          "provider_id": 352,
+          "provider_name": "AMC on Demand"
+        },
+        {
+          "display_priority": 168,
+          "logo_path": "/79mRAYq40lcYiXkQm6N7YErSSHd.jpg",
+          "provider_id": 486,
+          "provider_name": "Spectrum On Demand"
+        }
+      ]
+    },
+    "VE": {
+      "link": "https://www.themoviedb.org/movie/526896-morbius/watch?locale=VE",
+      "rent": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        }
+      ],
+      "buy": [
+        {
+          "display_priority": 2,
+          "logo_path": "/peURlLlr8jggOwK53fJ5wdQl05y.jpg",
+          "provider_id": 2,
+          "provider_name": "Apple iTunes"
+        },
+        {
+          "display_priority": 3,
+          "logo_path": "/tbEdFQDwx5LEVr8WpSeXQSIirVq.jpg",
+          "provider_id": 3,
+          "provider_name": "Google Play Movies"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This pull request implements the watch providers endpoint call which was introduced at the end of 20202.

This endpoint is unique in comparison to the others in that appending it requires a forward slash in the URL which is the reason for the enum changes. 

I have added mockito in order to test without the need for an API key. Happy to contribute some more tests at some point in the future

Docs: [https://developers.themoviedb.org/3/movies/get-movie-watch-providers](https://developers.themoviedb.org/3/movies/get-movie-watch-providers)