### PR TITLE
fix module info missing requirement + not exporting

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,7 +1,19 @@
 module info.movito.themoviedbapi {
     requires org.slf4j;
+    requires org.apache.commons.codec;
     requires org.apache.commons.lang3;
     requires com.fasterxml.jackson.annotation;
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
+
+    exports info.movito.themoviedbapi;
+    exports info.movito.themoviedbapi.model;
+    exports info.movito.themoviedbapi.model.changes;
+    exports info.movito.themoviedbapi.model.config;
+    exports info.movito.themoviedbapi.model.core;
+    exports info.movito.themoviedbapi.model.keywords;
+    exports info.movito.themoviedbapi.model.people;
+    exports info.movito.themoviedbapi.model.providers;
+    exports info.movito.themoviedbapi.model.tv;
+    exports info.movito.themoviedbapi.tools;
 }


### PR DESCRIPTION
After trying to use the updated (1.14 version) of this library, I ran into some errors. After checking I realised I forgot to export the parts of the library that should be public in my previous PR #136.

Changes:
- Added export to all packages that should be usable when importing this module
- Added a missing requires

Sorry for missing this.