### PR TITLE
Add collection to multi

### DIFF
--- a/src/main/java/info/movito/themoviedbapi/model/core/multi/Multi.java
+++ b/src/main/java/info/movito/themoviedbapi/model/core/multi/Multi.java
@@ -4,15 +4,13 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
- * Interface that is needed for /search/multi request
- * <p>
- * {@link MultiMovie}, {@link MultiPerson} and {@link MultiTvSeries} implement this interface.</p>
- * <p>Each of them returns corresponding {@link MediaType}</p>
+ * Interface that is needed for /search/multi request.
  *
  * @see info.movito.themoviedbapi.TmdbSearch#searchMulti(String, Boolean, String, Integer)
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "media_type")
 @JsonSubTypes({
+    @JsonSubTypes.Type(value = MultiCollection.class, name = "collection"),
     @JsonSubTypes.Type(value = MultiMovie.class, name = "movie"),
     @JsonSubTypes.Type(value = MultiPerson.class, name = "person"),
     @JsonSubTypes.Type(value = MultiTvSeries.class, name = "tv")
@@ -27,6 +25,7 @@ public interface Multi {
      * The type of media.
      */
     enum MediaType {
+        COLLECTION,
         MOVIE,
         PERSON,
         TV_SERIES

--- a/src/main/java/info/movito/themoviedbapi/model/core/multi/MultiCollection.java
+++ b/src/main/java/info/movito/themoviedbapi/model/core/multi/MultiCollection.java
@@ -1,0 +1,36 @@
+package info.movito.themoviedbapi.model.core.multi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import info.movito.themoviedbapi.model.core.IdElement;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class MultiCollection extends IdElement implements Multi {
+    @JsonProperty("adult")
+    private Boolean adult;
+
+    @JsonProperty("backdrop_path")
+    private String backdropPath;
+
+    @JsonProperty("original_language")
+    private String originalLanguage;
+
+    @JsonProperty("original_title")
+    private String originalTitle;
+
+    @JsonProperty("overview")
+    private String overview;
+
+    @JsonProperty("poster_path")
+    private String posterPath;
+
+    @JsonProperty("title")
+    private String title;
+
+    @Override
+    public MediaType getMediaType() {
+        return MediaType.COLLECTION;
+    }
+}

--- a/src/test/java/info/movito/themoviedbapi/TmdbSearchTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbSearchTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import info.movito.themoviedbapi.model.core.MovieResultsPage;
 import info.movito.themoviedbapi.model.core.TvSeriesResultsPage;
 import info.movito.themoviedbapi.model.core.multi.Multi;
+import info.movito.themoviedbapi.model.core.multi.MultiCollection;
 import info.movito.themoviedbapi.model.core.multi.MultiMovie;
 import info.movito.themoviedbapi.model.core.multi.MultiPerson;
 import info.movito.themoviedbapi.model.core.multi.MultiResultsPage;
@@ -28,7 +29,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for {@link TmdbSearch}.
  */
-public class TmdbTvSearchTest extends AbstractTmdbApiTest<TmdbSearch> {
+public class TmdbSearchTest extends AbstractTmdbApiTest<TmdbSearch> {
     @Override
     public TmdbSearch createApiToTest() {
         return getTmdbApi().getSearch();
@@ -112,7 +113,15 @@ public class TmdbTvSearchTest extends AbstractTmdbApiTest<TmdbSearch> {
         TestUtils.validateAbstractJsonMappingFields(multiResultsPage, multiValidatorConfig);
 
         List<Multi> results = multiResultsPage.getResults();
-        Multi multiMovie = results.get(0);
+
+        // collection
+        Multi multiCollection = results.get(0);
+        assertNotNull(multiCollection);
+        assertEquals(Multi.MediaType.COLLECTION, multiCollection.getMediaType());
+        TestUtils.validateAbstractJsonMappingFields((MultiCollection) multiCollection);
+
+        // movie
+        Multi multiMovie = results.get(1);
         assertNotNull(multiMovie);
         assertEquals(Multi.MediaType.MOVIE, multiMovie.getMediaType());
 
@@ -121,12 +130,14 @@ public class TmdbTvSearchTest extends AbstractTmdbApiTest<TmdbSearch> {
             .build();
         TestUtils.validateAbstractJsonMappingFields((MultiMovie) multiMovie, validatorConfig);
 
-        Multi multiTv = results.get(1);
+        // tv
+        Multi multiTv = results.get(2);
         assertNotNull(multiTv);
         assertEquals(Multi.MediaType.TV_SERIES, multiTv.getMediaType());
         TestUtils.validateAbstractJsonMappingFields((MultiTvSeries) multiTv);
 
-        Multi multiPerson = results.get(2);
+        // person
+        Multi multiPerson = results.get(3);
         assertNotNull(multiPerson);
         assertEquals(Multi.MediaType.PERSON, multiPerson.getMediaType());
         TestUtils.validateAbstractJsonMappingFields((MultiPerson) multiPerson);

--- a/src/test/java/info/movito/themoviedbapi/testutil/ValidatorConfig.java
+++ b/src/test/java/info/movito/themoviedbapi/testutil/ValidatorConfig.java
@@ -13,12 +13,16 @@ import lombok.Getter;
 public class ValidatorConfig {
     @Builder.Default
     private List<String> nullFieldsToIgnore = List.of();
+
     @Builder.Default
     private List<String> emptyCollectionFieldsToIgnore = List.of();
+
     @Builder.Default
     private List<String> nullContainingCollectionFieldsToIgnore = List.of();
+
     @Builder.Default
     private List<String> emptyMapFieldsToIgnore = List.of();
+
     @Builder.Default
     private List<String> nullContainingMapFieldsToIgnore = List.of();
 }

--- a/src/test/resources/api_responses/search/multi.json
+++ b/src/test/resources/api_responses/search/multi.json
@@ -3,6 +3,17 @@
     "results": [
         {
             "adult": false,
+            "backdrop_path": null,
+            "id": 1703735,
+            "title": "Star Wars spin off collection",
+            "original_title": "Star Wars spin off collection",
+            "overview": "",
+            "poster_path": null,
+            "media_type": "collection",
+            "original_language": "en"
+        },
+        {
+            "adult": false,
             "backdrop_path": "/aDYSnJAK0BTVeE8osOy22Kz3SXY.jpg",
             "id": 11,
             "title": "Star Wars",


### PR DESCRIPTION
Fix #329 

The docs state that this API should only be for movies, tv and people: https://developer.themoviedb.org/reference/search-multi
> Use multi search when you want to search for movies, TV shows and people in a single request.

But it seems collections are also present.

I tried many requests to see if any other media types were present in the response, but could not find any. This PR is just to add collections to the multi media types. If the other types are reported in the future, with examples, we can make a fix then.